### PR TITLE
Fix serializer argument to use ASCII key string in extensions.py

### DIFF
--- a/app/extensions.py
+++ b/app/extensions.py
@@ -5,7 +5,6 @@ from flask_cognito_lib import CognitoAuth
 from authlib.integrations.flask_client import OAuth
 from flask_session import Session
 from app.utils.encrypted_serializer import EncryptedSessionSerializer
-from cryptography.fernet import Fernet
 from app.config import Config
 
 db = SQLAlchemy()
@@ -14,4 +13,4 @@ csrf = CSRFProtect()
 cognito_auth = CognitoAuth()
 oauth = OAuth()
 session = Session()
-session.serializer = EncryptedSessionSerializer(Fernet(Config.FERNET_KEY))
+session.serializer = EncryptedSessionSerializer(Config.FERNET_KEY)


### PR DESCRIPTION
Fix serializer argument to use ASCII key string in extensions.py