### PR TITLE
chore(env): pin Python to 3.12.12 and MariaDB to 11.4.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-slim-bookworm
+FROM python:3.12.12-slim-bookworm
 WORKDIR /app
 RUN apt-get update && apt-get install -y --no-install-recommends \
     bash curl nano mariadb-client git \

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -1,4 +1,4 @@
-FROM python:3.12-slim-bookworm
+FROM python:3.12.12-slim-bookworm
 WORKDIR /app
 RUN apt-get update && apt-get install -y --no-install-recommends \
     bash curl mariadb-client git \

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,4 +1,4 @@
-FROM python:3.12-slim-bookworm
+FROM python:3.12.12-slim-bookworm
 WORKDIR /app
 RUN apt-get update && apt-get install -y --no-install-recommends \
     bash curl nano mariadb-client git \

--- a/compose.prod-local.yaml
+++ b/compose.prod-local.yaml
@@ -1,6 +1,6 @@
 services:
   db:
-    image: mariadb:11.4.4
+    image: mariadb:11.4.9
     restart: always
     ports:
       - "3306:3306"

--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -1,6 +1,6 @@
 services:
   db:
-    image: mariadb:11.4.4
+    image: mariadb:11.4.9
     restart: always
     ports:
       - "3306:3306"

--- a/compose.test.yaml
+++ b/compose.test.yaml
@@ -1,6 +1,6 @@
 services:
   db:
-    image: mariadb:11.4.4
+    image: mariadb:11.4.9
     restart: always
     ports:
       - "3306:3306"

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,6 +1,6 @@
 services:
   db:
-    image: mariadb:11.4.4
+    image: mariadb:11.4.9
     restart: always
     ports:
       - "3306:3306"


### PR DESCRIPTION
chore(env): pin Python to 3.12.12 and MariaDB to 11.4.9