### PR TITLE
Migrate/al2023/nat

### DIFF
--- a/terraform/migrate/.terraform.lock.hcl
+++ b/terraform/migrate/.terraform.lock.hcl
@@ -1,0 +1,24 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version = "6.42.0"
+  hashes = [
+    "h1:TB8wKN7RngMRmRFAciB2igunQprw2vCanXNr8lzjVRA=",
+    "zh:0dd774a97eaa4371a60e13b5dc56800d4fb1c48d50e79049f75fc4fe26705ff5",
+    "zh:237d652d8ec028f7bedce1ce056ffe42e2e120d2a4a47fe45b97263cc5948e7e",
+    "zh:367d9e4b816e5f857956887b8f0770aaa5bec47c4b1e2c7bf924e39192d580d6",
+    "zh:4194addb5b34bb803fab031a80d84e9d16cac2308df9a498d51e2214c7893900",
+    "zh:5bcc36226fa5d8a3c37e41ac8cfd2b1eb73e7ae96f8418f6776dcaa16a987198",
+    "zh:61d0632d4cc7973b779b90c1d3bb2d05a1cd4d7030bb4645831e67cf735ecaa0",
+    "zh:7c7efaf9e4bb662ba3e8a714abafe7107bdcd1bf2cd0867510ea32762debc11d",
+    "zh:7d7f8ffe00d4a90184efa454a107bcc46d81f21245baea9678dcfa2fa77ac1be",
+    "zh:7e534c454cdeafe9cc225bea53397883bb96c54da6ea3421fd53dbc9dfc1bb90",
+    "zh:99564c99a0672b2a8b666ab2040f36a7c6f372fa79ac43a6657a54734e46fff8",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a6b1bb6178798882508f5512222a9433fc21e63cdae83a755650c938e6141d32",
+    "zh:a87592d6ff3d46ee83756f4f84503b2fe4ffc9c1d5dc9f8d4afccb5e126ae538",
+    "zh:daa56fb74c5c9d26b327c40b486beac71cdb9a932c7c4e4561f4401cd0d16a4a",
+    "zh:f35ab043d7121f3a194f42f5b0e0d59fe62d94488acea07e3783405fa5838785",
+  ]
+}

--- a/terraform/migrate/nat_route.tf
+++ b/terraform/migrate/nat_route.tf
@@ -12,7 +12,7 @@ resource "aws_route" "private_nat_route" {
   route_table_id         = aws_route_table.private_ecs.id
   destination_cidr_block = "0.0.0.0/0"
 
-  instance_id            = aws_instance.nat_v2.id
+  network_interface_id   = aws_instance.nat_v2.primary_network_interface_id
 }
 
 # サブネットとの関連付け（AZ:1a）

--- a/terraform/migrate/nat_route.tf
+++ b/terraform/migrate/nat_route.tf
@@ -1,0 +1,28 @@
+# ルートテーブル管理
+resource "aws_route_table" "private_ecs" {
+  vpc_id = "vpc-09a84d9fab986d185"
+
+  tags = {
+    Name = "RT-Private-ECS"
+  }
+}
+
+# 0.0.0.0/0 のルート（nat-instance-v2へ向ける）
+resource "aws_route" "private_nat_route" {
+  route_table_id         = aws_route_table.private_ecs.id
+  destination_cidr_block = "0.0.0.0/0"
+
+  instance_id            = aws_instance.nat_v2.id
+}
+
+# サブネットとの関連付け（AZ:1a）
+resource "aws_route_table_association" "private_a" {
+  subnet_id      = "subnet-0e0b9d18dc475ea54"
+  route_table_id = aws_route_table.private_ecs.id
+}
+
+# サブネットとの関連付け（AZ:1c）
+resource "aws_route_table_association" "private_c" {
+  subnet_id      = "subnet-0a18a0ee8bc6ef495"
+  route_table_id = aws_route_table.private_ecs.id
+}


### PR DESCRIPTION
feat(network): migrate private route table and update NAT target
chore(terraform): lock aws provider version at v6.42.0
fix(network): use network_interface_id for nat route target
