### PR TITLE
chore(cd): remove trailing newline at the end of cd.yml

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -61,4 +61,3 @@ jobs:
           service: flask-service-rolling-update
           cluster: flask-cluster
           wait-for-service-stability: true
-


### PR DESCRIPTION
chore(cd): remove trailing newline at the end of cd.yml