### PR TITLE
chore(ecs): update service-rolling deployment percentages (0/100) to prevent port 5000 conflicts during auto-deployment

### DIFF
--- a/terraform/service-rolling.tf
+++ b/terraform/service-rolling.tf
@@ -23,10 +23,12 @@ resource "aws_ecs_service" "service_rolling" {
   desired_count   = 1
   launch_type     = "EC2"
 
+  deployment_minimum_healthy_percent = 0
+  deployment_maximum_percent         = 100
+
   deployment_controller {
     type = "ECS"
   }
-
 
   load_balancer {
     target_group_arn = aws_lb_target_group.rolling_tg.arn


### PR DESCRIPTION
chore(ecs): update service-rolling deployment percentages (0/100) to prevent port 5000 conflicts during auto-deployment