### PR TITLE
Fix/terraform/nat

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@
     | --- | --- |
     | 開発言語 | Python 3.12.12 |
     | フレームワーク | Flask 3.1.3 |
-    | データベース | MariaDB 11.4.9 |
+    | データベース | MariaDB 11.4.10 |
     | ソース管理 | Git |
     | リポジトリ | GitHub |
     | CI/CD | GitHub Actions |
@@ -170,7 +170,7 @@
     | 実行環境 | ECS (EC2起動タイプ) |
     | ホストOS | Amazon Linux 2023 |
     | アプリサーバー | Gunicorn |
-    | データベース | RDS (MariaDB 11.4.9) |
+    | データベース | RDS (MariaDB 11.4.10) |
     | 秘匿情報管理 | SSM Parameter Store（SecureString） |
     | イメージ管理 | ECR |
     | IaC | Terraform |

--- a/compose.prod-local.yaml
+++ b/compose.prod-local.yaml
@@ -1,6 +1,6 @@
 services:
   db:
-    image: mariadb:11.4.9
+    image: mariadb:11.4.10
     restart: always
     ports:
       - "3306:3306"

--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -1,6 +1,6 @@
 services:
   db:
-    image: mariadb:11.4.9
+    image: mariadb:11.4.10
     restart: always
     ports:
       - "3306:3306"

--- a/compose.test.yaml
+++ b/compose.test.yaml
@@ -1,6 +1,6 @@
 services:
   db:
-    image: mariadb:11.4.9
+    image: mariadb:11.4.10
     restart: always
     ports:
       - "3306:3306"

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,6 +1,6 @@
 services:
   db:
-    image: mariadb:11.4.9
+    image: mariadb:11.4.10
     restart: always
     ports:
       - "3306:3306"


### PR DESCRIPTION
fix(terraform): restore nat instance deleted during mariadb upgrade; update compose files to 11.4.10
docs(readme): update mariadb version to 11.4.10